### PR TITLE
Add missing command to notebook

### DIFF
--- a/colab/VAMPIRE_AGNews.ipynb
+++ b/colab/VAMPIRE_AGNews.ipynb
@@ -127,6 +127,7 @@
    },
    "outputs": [],
    "source": [
+    "!sh scripts/download_ag.sh\n",
     "!curl -Lo ag.tar https://s3-us-west-2.amazonaws.com/allennlp/datasets/ag-news/vampire_preprocessed_example.tar\n",
     "!tar -xvf ag.tar -C examples/\n",
     "!rm ag.tar"


### PR DESCRIPTION
The notebook is missing the command to download the AG News dataset (`!sh scripts/download_ag.sh`). Without it, the downstream classifier can't run in Colab. 